### PR TITLE
feat: Implement invisible menu, opacity control, and persist opacity

### DIFF
--- a/LousaInterativa/AppSettings.cs
+++ b/LousaInterativa/AppSettings.cs
@@ -12,6 +12,7 @@ namespace LousaInterativa
         public FormBorderStyle NormalFormBorderStyle { get; set; }
         public Size NormalFormSize { get; set; }
         public Point NormalFormLocation { get; set; }
+        public double FormOpacity { get; set; } // New property
 
         public AppSettings()
         {
@@ -22,6 +23,7 @@ namespace LousaInterativa
             NormalFormBorderStyle = FormBorderStyle.Sizable;
             NormalFormSize = new Size(816, 523); // Default size, can be adjusted. e.g. 800,600
             NormalFormLocation = new Point(100, 100); // Default location
+            FormOpacity = 1.0; // Default to 100% opaque
         }
     }
 }

--- a/LousaInterativa/Form1.Designer.cs
+++ b/LousaInterativa/Form1.Designer.cs
@@ -35,7 +35,10 @@ namespace LousaInterativa
             this.toolsMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.changeBackgroundColorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toggleTransparencyMenuItem = new System.Windows.Forms.ToolStripMenuItem(); // Instantiation
+            this.opacityTrackBar = new System.Windows.Forms.TrackBar();
+            this.adjustOpacityMenuItem = new System.Windows.Forms.ToolStripMenuItem(); // Instantiation
             this.menuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.opacityTrackBar)).BeginInit();
             this.SuspendLayout();
             //
             // viewMenu
@@ -66,7 +69,8 @@ namespace LousaInterativa
             // toolsMenu
             //
             this.toolsMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.changeBackgroundColorMenuItem});
+            this.changeBackgroundColorMenuItem,
+            this.adjustOpacityMenuItem}); // Added here
             this.toolsMenu.Name = "toolsMenu";
             this.toolsMenu.Size = new System.Drawing.Size(46, 20);
             this.toolsMenu.Text = "Tools";
@@ -74,9 +78,17 @@ namespace LousaInterativa
             // changeBackgroundColorMenuItem
             //
             this.changeBackgroundColorMenuItem.Name = "changeBackgroundColorMenuItem";
-            this.changeBackgroundColorMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.changeBackgroundColorMenuItem.Size = new System.Drawing.Size(200, 22); // Keep consistent if possible
             this.changeBackgroundColorMenuItem.Text = "Change Background Color";
             this.changeBackgroundColorMenuItem.Click += new System.EventHandler(this.changeBackgroundColorMenuItem_Click);
+            //
+            // adjustOpacityMenuItem
+            //
+            this.adjustOpacityMenuItem.Name = "adjustOpacityMenuItem";
+            this.adjustOpacityMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F9;
+            this.adjustOpacityMenuItem.Size = new System.Drawing.Size(200, 22); // Consistent size
+            this.adjustOpacityMenuItem.Text = "&Adjust Opacity";
+            this.adjustOpacityMenuItem.Click += new System.EventHandler(this.adjustOpacityMenuItem_Click);
             //
             // menuStrip1
             //
@@ -88,12 +100,27 @@ namespace LousaInterativa
             this.menuStrip1.Size = new System.Drawing.Size(800, 24);
             this.menuStrip1.TabIndex = 0;
             this.menuStrip1.Text = "menuStrip1";
+            this.menuStrip1.Visible = false; // Make menuStrip1 invisible by default
+            //
+            // opacityTrackBar
+            //
+            this.opacityTrackBar.Dock = System.Windows.Forms.DockStyle.Top;
+            this.opacityTrackBar.Location = new System.Drawing.Point(0, 24); // Location is illustrative, Dock takes precedence
+            this.opacityTrackBar.Maximum = 100;
+            this.opacityTrackBar.Name = "opacityTrackBar";
+            this.opacityTrackBar.Size = new System.Drawing.Size(800, 45);    // Size is illustrative, Dock takes precedence for width
+            this.opacityTrackBar.TabIndex = 1;
+            this.opacityTrackBar.TickFrequency = 10;
+            this.opacityTrackBar.Value = 100; // Default to 100% opaque
+            this.opacityTrackBar.Visible = false; // Initially hidden
+            this.opacityTrackBar.Scroll += new System.EventHandler(this.opacityTrackBar_Scroll);
             //
             // Form1
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.opacityTrackBar); // Added TrackBar
             this.Controls.Add(this.menuStrip1);
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "Form1";
@@ -102,6 +129,7 @@ namespace LousaInterativa
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Form1_KeyDown);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.opacityTrackBar)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -115,5 +143,7 @@ namespace LousaInterativa
         private System.Windows.Forms.ToolStripMenuItem toolsMenu;
         private System.Windows.Forms.ToolStripMenuItem changeBackgroundColorMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toggleTransparencyMenuItem; // Declaration
+        private System.Windows.Forms.TrackBar opacityTrackBar; // Declaration
+        private System.Windows.Forms.ToolStripMenuItem adjustOpacityMenuItem; // Declaration
     }
 }

--- a/LousaInterativa/Form1.cs
+++ b/LousaInterativa/Form1.cs
@@ -17,6 +17,7 @@ namespace LousaInterativa
         private FormBorderStyle _transparencyPreviousFormBorderStyle;
         private Color _lastOpaqueBackColor;
         private readonly System.Drawing.Color _magicOpaqueKeyForTransparency = System.Drawing.Color.FromArgb(255, 7, 7, 7); // An arbitrary, opaque, dark color
+        private double _currentFormOpacity = 1.0; // Field for current form opacity level
 
         public Form1()
         {
@@ -37,14 +38,20 @@ namespace LousaInterativa
             this.FormBorderStyle = _currentSettings.NormalFormBorderStyle;
             this.BackColor = Color.FromArgb(_currentSettings.LastBackColorAsArgb);
 
+            // Initialize _currentFormOpacity and set form Opacity directly from settings
+            this._currentFormOpacity = _currentSettings.FormOpacity;
+            if (this._currentFormOpacity < 0.0) this._currentFormOpacity = 0.0; // Clamp
+            if (this._currentFormOpacity > 1.0) this._currentFormOpacity = 1.0; // Clamp
+            this.Opacity = this._currentFormOpacity;
+
             // Initialize internal state fields based on loaded & applied settings
             _lastOpaqueBackColor = this.BackColor;
             _previousFormBorderStyle = this.FormBorderStyle; // For full-screen feature's runtime restoration
             _previousWindowState = this.WindowState;       // For full-screen feature's runtime restoration
-            // _transparencyPreviousFormBorderStyle will be set when transparency is first toggled by user or load,
-            // or it might be implicitly set if loading into a transparent borderless state.
+            // _transparencyPreviousFormBorderStyle will be set when transparency is first toggled by user or load.
 
             // Apply states if they were active
+            // Note: ToggleFullScreen() and ToggleWindowTransparency() will call SaveSettings.
             if (_currentSettings.IsFullScreen)
             {
                 ToggleFullScreen(); // This will set _isFullScreen and save settings
@@ -91,6 +98,7 @@ namespace LousaInterativa
             _currentSettings.LastBackColorAsArgb = _lastOpaqueBackColor.ToArgb();
             _currentSettings.IsFullScreen = _isFullScreen;
             _currentSettings.WasWindowTransparent = _isWindowTransparent;
+            _currentSettings.FormOpacity = this._currentFormOpacity; // Ensure final opacity is saved
 
             SettingsManager.SaveSettings(_currentSettings);
         }
@@ -162,6 +170,19 @@ namespace LousaInterativa
             }
             else // Activate transparency
             {
+                // If form is semi-transparent via Opacity property, make it fully opaque first
+                // for TransparencyKey to work reliably.
+                if (this.Opacity < 1.0)
+                {
+                    this.Opacity = 1.0;
+                    this._currentFormOpacity = 1.0;
+                    if (this._currentSettings != null)
+                    {
+                        this._currentSettings.FormOpacity = 1.0;
+                        // Settings will be saved by the general SaveSettings call below
+                    }
+                }
+
                 // Store the current border style (which might be None if full-screen)
                 // This is so we can revert to it if transparency is toggled off.
                 _transparencyPreviousFormBorderStyle = this.FormBorderStyle;
@@ -173,7 +194,46 @@ namespace LousaInterativa
                 _isWindowTransparent = true;
             }
             _currentSettings.WasWindowTransparent = _isWindowTransparent;
+            // Save all relevant settings, including potential FormOpacity change
             SettingsManager.SaveSettings(_currentSettings);
+        }
+
+        private void ApplyFormOpacity(double opacityLevel, bool saveSetting = true)
+        {
+            // Clamp opacityLevel between 0.0 (fully transparent) and 1.0 (fully opaque)
+            if (opacityLevel < 0.0) opacityLevel = 0.0;
+            if (opacityLevel > 1.0) opacityLevel = 1.0;
+
+            // If trying to make semi-transparent (Opacity < 1.0) AND
+            // full-key transparency (_isWindowTransparent) is currently active,
+            // then deactivate full-key transparency first.
+            if (opacityLevel < 1.0 && this._isWindowTransparent)
+            {
+                // ToggleWindowTransparency will call SaveSettings, potentially saving an
+                // Opacity of 1.0 if it was just set by ToggleWindowTransparency.
+                // Then, the lines below will apply the desired semi-transparent opacityLevel.
+                ToggleWindowTransparency();
+            }
+
+            this.Opacity = opacityLevel;
+            this._currentFormOpacity = opacityLevel;
+
+            if (saveSetting)
+            {
+                if (this._currentSettings != null) // Ensure settings object exists
+                {
+                    this._currentSettings.FormOpacity = this._currentFormOpacity;
+                    // Avoid double save if ToggleWindowTransparency was called and saved.
+                    // However, if ToggleWindowTransparency was *not* called, we need to save.
+                    // For simplicity, always saving here is acceptable, or add more complex flag.
+                    // Let's assume ToggleWindowTransparency already saved if it was called.
+                    // A more robust way: check if opacity actually changed due to ToggleWindowTransparency.
+                    // For now, if opacityLevel < 1.0 and _isWindowTransparent was true, a save already happened.
+                    // This check is imperfect. A better way would be for ToggleWindowTransparency to return a bool.
+                    // Simplification: if saveSetting is true, we save. The state will be consistent.
+                    SettingsManager.SaveSettings(this._currentSettings);
+                }
+            }
         }
 
         // Helper method to determine the "true" normal FormBorderStyle
@@ -192,6 +252,12 @@ namespace LousaInterativa
             }
         }
 
+        private void opacityTrackBar_Scroll(object sender, EventArgs e)
+        {
+            double newOpacity = (double)this.opacityTrackBar.Value / 100.0;
+            ApplyFormOpacity(newOpacity); // saveSetting defaults to true
+        }
+
         private void fullScreenMenuItem_Click(object sender, System.EventArgs e)
         {
             ToggleFullScreen();
@@ -208,6 +274,25 @@ namespace LousaInterativa
             {
                 ToggleWindowTransparency();
                 e.Handled = true; // Prevent further processing of F10
+            }
+            else if (e.KeyCode == Keys.F9) // New condition for F9
+            {
+                this.opacityTrackBar.Visible = !this.opacityTrackBar.Visible;
+                if (this.opacityTrackBar.Visible)
+                {
+                    this.opacityTrackBar.Value = (int)(this._currentFormOpacity * 100);
+                }
+                e.Handled = true; // Prevent further processing of F9
+            }
+        }
+
+        private void adjustOpacityMenuItem_Click(object sender, EventArgs e)
+        {
+            this.opacityTrackBar.Visible = !this.opacityTrackBar.Visible;
+            if (this.opacityTrackBar.Visible)
+            {
+                // Update TrackBar's value to reflect current form opacity when it becomes visible
+                this.opacityTrackBar.Value = (int)(this._currentFormOpacity * 100);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Lousa Interativa (Interactive Whiteboard) is a simple Windows Forms application designed to provide a basic digital whiteboard experience. It allows users to change the background color, including transparency, and toggle a full-screen mode for an immersive experience.
 
+## User Interface Notes
+-   **Menu Access:** The main menu bar is hidden by default to maximize the content area. Access menu commands by pressing the `Alt` key, which will reveal or allow interaction with the menu via standard Windows behavior (e.g., `Alt+T` for Tools, `Alt+V` for View).
+
 ## Features
 
 -   **Full-Screen Mode:**
@@ -11,15 +14,22 @@ Lousa Interativa (Interactive Whiteboard) is a simple Windows Forms application 
 -   **Customizable Background Color:**
     -   Change the application's background color via the **Tools > Change Background Color** menu option.
     -   A color dialog allows selection of any color, including alpha (transparency) values for a semi-transparent background.
--   **Toggle Window Transparency:**
-    -   Activate/deactivate full window transparency, making the client area see-through and removing borders.
+-   **Toggle Window Transparency (F10 / View Menu):**
+    -   Activate/deactivate full window transparency, making the client area see-through and removing borders (using `TransparencyKey` mechanism).
     -   Toggle with the **F10** key or via the **View > Toggle Transparency** menu option.
     -   When transparency is deactivated, the previously chosen background color and form style are restored.
+    -   Activating this mode will set the form opacity to 100% (fully opaque) for the `TransparencyKey` effect to work correctly.
+-   **Adjustable Form Opacity (F9 / Tools Menu):**
+    -   Control the overall transparency level of the application window (from 0% to 100%) using the `Opacity` property.
+    -   Accessed via the **Tools > Adjust Opacity** menu option or by pressing the **F9** key. This toggles a TrackBar control at the top of the window.
+    -   This opacity setting affects the entire window, including borders and all controls.
+    -   Setting an opacity level below 100% will deactivate the 'Toggle Window Transparency' (F10) mode if it's active.
 -   **Settings Persistence:**
     -   The application automatically saves your last used settings:
         -   Background color
         -   Full-screen state
-        -   Window transparency state
+        -   Window transparency state (on/off for F10 mode)
+        -   Form Opacity level (for F9 control)
         -   Normal window size and location
     -   These settings are loaded when the application starts, restoring your previous session's look and feel. Settings are stored in an XML file in your local application data folder (`%LOCALAPPDATA%/LousaInterativaCompany/LousaInterativaApp/settings.xml`).
 


### PR DESCRIPTION
This commit introduces several UI and functionality enhancements:

1.  **Invisible Menu by Default**:
    - The main MenuStrip (`menuStrip1`) is now hidden by default (`Visible = false`).
    - Standard Windows Alt-key activation should allow you to access menu commands.

2.  **Adjustable Form Opacity (Semi-Transparency)**:
    - You can now control the overall opacity of the main form (from 0% to 100%) using the `Form.Opacity` property.
    - A `TrackBar` UI control (`opacityTrackBar`), docked at the top of the form, allows graphical adjustment of this opacity.
    - The `TrackBar` is hidden by default and can be toggled using:
        - A new menu item: "Tools > Adjust Opacity".
        - The F9 function key.
    - When the `TrackBar` becomes visible, its value is synchronized with the current form opacity.

3.  **Interaction between Opacity Types**:
    - Setting Form Opacity to less than 100% will deactivate the existing F10/"Toggle Window Transparency" mode (which uses `TransparencyKey` for full, keyed transparency).
    - Activating the F10/"Toggle Window Transparency" mode will first set the Form Opacity to 100% to ensure the `TransparencyKey` effect is clear and not compounded with semi-opacity.

4.  **Persistence of Form Opacity**:
    - The chosen Form Opacity level is now saved to the `settings.xml` file.
    - This setting is loaded upon application startup and applied.

5.  **README Update**:
    - The `README.md` file has been updated to reflect these new features, including how to access the hidden menu and details about the opacity controls.

These changes provide more flexible transparency options and a cleaner default UI by hiding the menu.