### PR TITLE
feat: Add Toolbar and basic Pen tool activation

### DIFF
--- a/LousaInterativa/Form1.Designer.cs
+++ b/LousaInterativa/Form1.Designer.cs
@@ -38,8 +38,11 @@ namespace LousaInterativa
             this.opacityTrackBar = new System.Windows.Forms.TrackBar();
             this.adjustOpacityMenuItem = new System.Windows.Forms.ToolStripMenuItem(); // Instantiation
             this.toggleMenuVisibilityMenuItem = new System.Windows.Forms.ToolStripMenuItem(); // Instantiation
+            this.mainToolStrip = new System.Windows.Forms.ToolStrip(); // Instantiation
+            this.penToolStripButton = new System.Windows.Forms.ToolStripButton(); // Instantiation
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.opacityTrackBar)).BeginInit();
+            this.mainToolStrip.SuspendLayout(); // For adding items
             this.SuspendLayout();
             //
             // viewMenu
@@ -124,13 +127,39 @@ namespace LousaInterativa
             this.opacityTrackBar.Visible = false; // Initially hidden
             this.opacityTrackBar.Scroll += new System.EventHandler(this.opacityTrackBar_Scroll);
             //
+            // mainToolStrip
+            //
+            this.mainToolStrip.Dock = System.Windows.Forms.DockStyle.Top;
+            this.mainToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.mainToolStrip.Location = new System.Drawing.Point(0, 0); // Actual Y will be below opacityTrackBar
+            this.mainToolStrip.Name = "mainToolStrip";
+            this.mainToolStrip.Size = new System.Drawing.Size(800, 25); // Height 25, width will be auto
+            this.mainToolStrip.TabIndex = 2; // After menuStrip1 (0) and opacityTrackBar (1)
+            this.mainToolStrip.Text = "mainToolStrip";
+            this.mainToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.penToolStripButton});
+            //
+            // penToolStripButton
+            //
+            this.penToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.penToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.penToolStripButton.Name = "penToolStripButton";
+            this.penToolStripButton.Size = new System.Drawing.Size(34, 22); // Example text-based size
+            this.penToolStripButton.Text = "Pen";
+            this.penToolStripButton.CheckOnClick = true;
+            this.penToolStripButton.Click += new System.EventHandler(this.penToolStripButton_Click);
+            //
             // Form1
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.opacityTrackBar); // Added TrackBar
+            // Corrected order for DockStyle.Top: Last added is lowest.
+            // To have opacityTrackBar at the top, then mainToolStrip, then menuStrip1 (if visible):
+            // Add menuStrip1 first, then mainToolStrip, then opacityTrackBar.
             this.Controls.Add(this.menuStrip1);
+            this.Controls.Add(this.mainToolStrip);
+            this.Controls.Add(this.opacityTrackBar);
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "Form1";
             this.Text = "Form1";
@@ -139,6 +168,8 @@ namespace LousaInterativa
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.opacityTrackBar)).EndInit();
+            this.mainToolStrip.ResumeLayout(false);
+            this.mainToolStrip.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -155,5 +186,7 @@ namespace LousaInterativa
         private System.Windows.Forms.TrackBar opacityTrackBar; // Declaration
         private System.Windows.Forms.ToolStripMenuItem adjustOpacityMenuItem; // Declaration
         private System.Windows.Forms.ToolStripMenuItem toggleMenuVisibilityMenuItem; // Declaration
+        private System.Windows.Forms.ToolStrip mainToolStrip; // Declaration
+        private System.Windows.Forms.ToolStripButton penToolStripButton; // Declaration
     }
 }

--- a/LousaInterativa/Form1.cs
+++ b/LousaInterativa/Form1.cs
@@ -18,6 +18,7 @@ namespace LousaInterativa
         private Color _lastOpaqueBackColor;
         private readonly System.Drawing.Color _magicOpaqueKeyForTransparency = System.Drawing.Color.FromArgb(255, 7, 7, 7); // An arbitrary, opaque, dark color
         private double _currentFormOpacity = 1.0; // Field for current form opacity level
+        private bool _isPenToolActive = false; // Field for pen tool state
 
         public Form1()
         {
@@ -298,6 +299,24 @@ namespace LousaInterativa
         {
             double newOpacity = (double)this.opacityTrackBar.Value / 100.0;
             ApplyFormOpacity(newOpacity); // saveSetting defaults to true
+        }
+
+        private void penToolStripButton_Click(object sender, EventArgs e)
+        {
+            // penToolStripButton.Checked state is automatically toggled due to CheckOnClick = true
+            this._isPenToolActive = this.penToolStripButton.Checked;
+
+            if (this._isPenToolActive)
+            {
+                this.Cursor = System.Windows.Forms.Cursors.Cross; // Use Crosshair cursor as placeholder for pen
+
+                // Future: If other tools exist, ensure they are unchecked.
+                // Example: if (this.eraserToolStripButton != null) this.eraserToolStripButton.Checked = false;
+            }
+            else
+            {
+                this.Cursor = System.Windows.Forms.Cursors.Default;
+            }
         }
 
         private void fullScreenMenuItem_Click(object sender, System.EventArgs e)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Lousa Interativa (Interactive Whiteboard) is a simple Windows Forms application 
     -   Alternatively, use the **View > Show/Hide Menu** option. This menu item displays a checkmark if the menu is currently visible.
     -   Even if the menu bar is hidden, menu commands can typically be accessed by pressing the `Alt` key (e.g., `Alt+V` for the View menu, then navigate with arrow keys or mnemonics like 'M' for "Show/Hide Menu").
 
+## Toolbar
+The application features a toolbar docked at the top of the window (below the opacity adjustment trackbar, if visible) for quick access to drawing tools and other commands.
+
+### Drawing Tools
+*   **Pen Tool:**
+    *   **Button:** "Pen" (text button on the toolbar).
+    *   **Functionality:** Click to activate or deactivate Pen mode. When active, the mouse cursor changes to a crosshair, indicating that drawing input is expected.
+    *   *(Note: Actual drawing on the canvas is not yet implemented.)*
+
 ## Features
 
 -   **Full-Screen Mode (F11 / View Menu):**
@@ -29,7 +38,7 @@ Lousa Interativa (Interactive Whiteboard) is a simple Windows Forms application 
         -   Full-screen state
         -   Window transparency state (on/off for F10 mode)
         -   Form Opacity level (for F9 control)
-        -   **Menu Bar Visibility (shown/hidden)**
+        -   Menu Bar Visibility (shown/hidden)
         -   Normal window size and location
     -   Settings are stored in an XML file: `%LOCALAPPDATA%/LousaInterativaCompany/LousaInterativaApp/settings.xml`.
 


### PR DESCRIPTION
This commit introduces the initial Toolbar and a basic Pen tool.

Key changes:
1.  **ToolStrip Creation (`mainToolStrip`):**
    - Added a `ToolStrip` control to `Form1`, docked to the top of the window (below the opacity trackbar, if visible).
    - `GripStyle` is hidden.

2.  **Pen Tool Button (`penToolStripButton`):**
    - Added a "Pen" `ToolStripButton` to the `mainToolStrip`.
    - It's currently a text-based button.
    - `CheckOnClick` is enabled to allow a toggled active/inactive state.

3.  **Pen Tool Activation Logic:**
    - Implemented the `Click` event handler for `penToolStripButton` in `Form1.cs`.
    - Toggling the Pen button now:
        - Sets an internal `_isPenToolActive` flag.
        - Changes the mouse cursor to `Cursors.Cross` when the Pen tool is active, and back to `Cursors.Default` when inactive.
    - Actual drawing functionality is not yet implemented with this tool.

4.  **README Update:**
    - Documented the new Toolbar and the Pen tool's current capabilities (activation and cursor change).

This provides the foundation for future drawing tool implementations.